### PR TITLE
Fix log-driver and log-opt tests

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,6 +27,8 @@ class docker::service (
   $tcp_bind         = $docker::tcp_bind,
   $socket_bind      = $docker::socket_bind,
   $log_level        = $docker::log_level,
+  $log_driver       = $docker::log_driver,
+  $log_opt          = $docker::log_opt,
   $selinux_enabled  = $docker::selinux_enabled,
   $socket_group     = $docker::socket_group,
   $dns              = $docker::dns,


### PR DESCRIPTION
This PR fixes puppet 4 tests so it can be merged. 

Variables were not actually written to the files causing tests to fail.
